### PR TITLE
FLORIS wakes

### DIFF
--- a/amrwind_frontend.py
+++ b/amrwind_frontend.py
@@ -812,6 +812,7 @@ class MyApp(tkyg.App, object):
     from farmfunctions import turbines_createAllTurbines, turbines_previewAllTurbines
     from farmfunctions import sampling_createAllProbes
     from farmfunctions import sweep_SetupRunParamSweep
+    from farmfunctions import floris_setup
 
     def getMaxLevel(self):
         max_level = 0

--- a/amrwind_frontend.py
+++ b/amrwind_frontend.py
@@ -1087,6 +1087,9 @@ class MyApp(tkyg.App, object):
 
     def ABL_calculateWDirWS(self):
         Wvec   = self.inputvars['ABL_velocity'].getval()
+        if Wvec is None:
+            print('ABL_calculateWDirWS() called',
+                  'but ABL_velocity vector not specified')
         Uhoriz = np.sqrt(Wvec[0]**2 + Wvec[1]**2)
         # Check for North/East vector
         thetaoffset = self.get_N_angle_to_Y()

--- a/config.yaml
+++ b/config.yaml
@@ -2224,7 +2224,7 @@ popupwindow:
     title:        Plot domain     # optional
     loadonstart:  True            # optional
     width:        350
-    height:       680
+    height:       720
     frames:
       - name:       plot_frameoverall
         title:      Plot settings
@@ -2265,6 +2265,11 @@ popupwindow:
         label:      Plot wind & N arrows
         inputtype:  bool
         defaultval: True
+      - name:       plot_florissoln
+        frame:      plot_frameoverall
+        label:      Plot FLORIS wake solution
+        inputtype:  bool
+        defaultval: False
       - name:       plot_sampleprobes
         frame:      plot_framesampleprobes
         label:      #Plot sample probes

--- a/farm.yaml
+++ b/farm.yaml
@@ -120,6 +120,11 @@ frames:
     row:   2
     kwargs:
       borderwidth: 0
+
+  - name:  frame_floris
+    tab:   Farm
+    title: Setup FLORIS
+    toggled: True
       
 inputwidgets:
   - name:       farm_setupfile
@@ -473,6 +478,24 @@ inputwidgets:
       help:      Log file to record each run
       farmsetup: sweep_logfile
 
+  # -------- FLORIS inputs ---------------------------------
+  - name:       floris_inputfile
+    frame:      frame_floris
+    label:      YAML file
+    inputtype:  str #filename
+    row:        1
+    defaultval: 'floris.inp'
+    entryopt:
+      width:    25
+    fileopenopt:
+      selecttype: saveas
+      kwargs:
+        filetypes:
+          - ["YAML files", "*.yaml"]
+          - ["input files", "*.inp"]
+          - ["all files", "*.*"]
+    outputdef:
+      help:     YAML file with FLORIS settings
 
   # -------- Hidden/extra inputs ---------------------------
   - name:       wfarm_embedamrwindinput
@@ -574,6 +597,11 @@ buttons:
     command: self.sweep_SetupRunParamSweep
     #command: self.donothing_button
 
+  - name:    farmbutton_generatefloris
+    text:    Generate
+    frame:   frame_floris
+    command: "self.floris_setup"
+
   # --- Help buttons ---
   - name:     helpbutton_farmturbinecsv
     text:     "[?]"
@@ -626,7 +654,6 @@ buttons:
       padx:   1
     gridoptions:
       sticky: 'NE'
-
 
 # Add all help messages and buttons in here
 helpwindows:

--- a/farm.yaml
+++ b/farm.yaml
@@ -484,7 +484,7 @@ inputwidgets:
     label:      YAML file
     inputtype:  str #filename
     row:        1
-    defaultval: 'floris.inp'
+    defaultval: 'floris.yaml'
     entryopt:
       width:    25
     fileopenopt:
@@ -492,7 +492,6 @@ inputwidgets:
       kwargs:
         filetypes:
           - ["YAML files", "*.yaml"]
-          - ["input files", "*.inp"]
           - ["all files", "*.*"]
     outputdef:
       help:     YAML file with FLORIS settings

--- a/floris_template.yaml
+++ b/floris_template.yaml
@@ -1,0 +1,89 @@
+
+name: GCH
+description: Template based on three-turbine Gauss Curl Hybrid model example
+floris_version: v3.0.0
+
+logging:
+  console:
+    enable: true
+    level: WARNING
+  file:
+    enable: false
+    level: WARNING
+
+solver:
+  type: turbine_grid
+  turbine_grid_points: 3
+
+farm:
+  layout_x:
+  - 0.0
+  - 630.0
+  - 1260.0
+  layout_y:
+  - 0.0
+  - 0.0
+  - 0.0
+  turbine_type:
+  - nrel_5MW
+
+flow_field:
+  air_density: 1.225
+  reference_wind_height: -1 # -1 is code for use the hub height
+  turbulence_intensity: 0.06
+  wind_directions:
+  - 270.0
+  wind_shear: 0.12
+  wind_speeds:
+  - 8.0
+  wind_veer: 0.0
+
+wake:
+  model_strings:
+    combination_model: sosfs
+    deflection_model: gauss
+    turbulence_model: crespo_hernandez
+    velocity_model: gauss
+
+  enable_secondary_steering: true
+  enable_yaw_added_recovery: true
+  enable_transverse_velocities: true
+
+  wake_deflection_parameters:
+    gauss:
+      ad: 0.0
+      alpha: 0.58
+      bd: 0.0
+      beta: 0.077
+      dm: 1.0
+      ka: 0.38
+      kb: 0.004
+    jimenez:
+      ad: 0.0
+      bd: 0.0
+      kd: 0.05
+
+  wake_velocity_parameters:
+    cc:
+      a_s: 0.179367259
+      b_s: 0.0118889215
+      c_s1: 0.0563691592
+      c_s2: 0.13290157
+      a_f: 3.11
+      b_f: -0.68
+      c_f: 2.41
+      alpha_mod: 1.0
+    gauss:
+      alpha: 0.58
+      beta: 0.077
+      ka: 0.38
+      kb: 0.004
+    jensen:
+      we: 0.05
+
+  wake_turbulence_parameters:
+    crespo_hernandez:
+      initial: 0.1
+      constant: 0.5
+      ai: 0.8
+      downstream: -0.32

--- a/plotfunctions.py
+++ b/plotfunctions.py
@@ -8,6 +8,7 @@
 """
 Plotting functions
 """
+import os
 import numpy as np
 from collections            import OrderedDict 
 from matplotlib.collections import PatchCollection
@@ -439,6 +440,14 @@ def plotDomain(self, ax=None):
 
             plotTurbine(ax, basepos, turbhh, turbD, yaw, ix, iy,
                         lw=1, color='k', alpha=0.75)
+
+    # Plot the turbines
+    # ---------------------------
+    if plotparams['plot_florissoln']:
+        if not os.path.isfile(self.inputvars['floris_inputfile'].getval()):
+            print('Need to run Farm > Setup FLORIS > Generate')
+        else:
+            print('Plotting wakes')
 
     # --------------------------------
     # Set some plot formatting parameters


### PR DESCRIPTION
@lawrenceccheung, as we discussed, I've put together a demo, tested with FLORIS v3.2, to produce the following (note the turbines have different yaw misalignments relative to the mean wind):
 
![domain_with_floris](https://user-images.githubusercontent.com/18267059/192154248-97096be8-cf19-491a-8d04-96f636ad889c.png)

This is the test domain / turbine config: [floris_test_setup.inp.txt](https://github.com/Exawind/amr-wind-frontend/files/9641246/floris_test_setup.inp.txt). The floris.yaml input file is generated under the "Farm" tab. 

Todo:
- [ ] Set up FLORIS for arbitrary turbine models, based on actuator disk Cp / Ct (currently NREL5MW is hard-coded)
- [ ] Set up slicing in vertical/cross-stream planes
- [ ] ...?

