### PR TITLE
Minor tweaks to averageplanes

### DIFF
--- a/postproengine/averageplanes.py
+++ b/postproengine/averageplanes.py
@@ -108,7 +108,7 @@ avgplanes:
             else:
                 # Compute the result
                 self.dbavg  = ppsamplexr.avgPlaneXR(filelist, tavg, varnames=varnames, groupname=group,
-                                                    includeattr=False, savepklfile=pklfile, verbose=verbose)
+                                                    includeattr=True, savepklfile=pklfile, verbose=verbose)
             
             # Do any sub-actions required for this task
             for a in self.actionlist:

--- a/postproengine/doc/README.md
+++ b/postproengine/doc/README.md
@@ -4,8 +4,8 @@
 The following workflows are available:
 
 - [avgplanes](avgplanes.md): Average netcdf sample planes
-- [instantaneousplanes](instantaneousplanes.md): Make instantaneous plots from netcdf sample planes
 - [convert](convert.md): Converts netcdf sample planes to different file formats
+- [instantaneousplanes](instantaneousplanes.md): Make instantaneous plots from netcdf sample planes
 - [openfast](openfast.md): Postprocessing of openfast variables
 - [reynoldsstress](reynoldsstress.md): Reynolds-Stress average netcdf sample planes
 - [wake_meander](wake_meander.md): Compute wake meandering statistics

--- a/postproengine/doc/avgplanes.md
+++ b/postproengine/doc/avgplanes.md
@@ -6,8 +6,7 @@ Average netcdf sample planes
   name                : An arbitrary name (Required)
   ncfile              : NetCDF sampling file (Required)
   tavg                : Which times to average over (Optional, Default: [])
-  xaxis               : Which axis to use on the abscissa (Optional, Default: 'x')
-  yaxis               : Which axis to use on the ordinate (Optional, Default: 'y')
+  loadpklfile         : Load previously computed results from this pickle file (Optional, Default: '')
   savepklfile         : Name of pickle file to save results (Optional, Default: '')
   group               : Which group to pull from netcdf file (Optional, Default: None)
   varnames            : Variables to extract from the netcdf file (Optional, Default: ['velocityx', 'velocityy', 'velocityz'])
@@ -35,4 +34,22 @@ Average netcdf sample planes
     ylabel            : Label on the Y-axis (Optional, Default: 'Y [m]')
     title             : Title of the plot (Optional, Default: '')
     plotfunc          : Function to plot (lambda expression) (Optional, Default: 'lambda u, v, w: u')
+```
+
+## Example
+```yaml
+avgplanes:
+  - name: avg_smallXYplane
+    ncfile:
+    - /lustre/orion/cfd162/world-shared/lcheung/AdvancedControlsWakes/Runs/LowWS_LowTI.Frontier/oneturb_7x2/rundir_baseline/post_processing/XY_35000.nc
+    - /lustre/orion/cfd162/world-shared/lcheung/AdvancedControlsWakes/Runs/LowWS_LowTI.Frontier/oneturb_7x2/rundir_baseline/post_processing/XY_50000.nc
+    - /lustre/orion/cfd162/world-shared/lcheung/AdvancedControlsWakes/Runs/LowWS_LowTI.Frontier/oneturb_7x2/rundir_baseline/post_processing/XY_65000.nc    
+    - /lustre/orion/cfd162/world-shared/lcheung/AdvancedControlsWakes/Runs/LowWS_LowTI.Frontier/oneturb_7x2/rundir_baseline/post_processing/XY_77500.nc
+    tavg: [17800, 18500]
+    plot:
+      plotfunc: 'lambda u, v, w: np.sqrt(u**2 + v**2)'
+      title: 'AVG horizontal velocity'
+      xaxis: x           # Which axis to use on the abscissa 
+      yaxis: y           # Which axis to use on the ordinate 
+      iplane: 1    
 ```


### PR DESCRIPTION
Some minor tweaks to avgplanes, including:
- Adding examples to documentation
- Added `loadpklfile` option to load results from pickle file instead of computing 
- Made `includeattr=True` the default to `avgPlaneXR()`
- Removed unnecessary `xaxis` and `yaxis` options to main executor