### PR TITLE
Fix bug in subaction loop

### DIFF
--- a/postproengine/averageplanes.py
+++ b/postproengine/averageplanes.py
@@ -77,7 +77,7 @@ avgplanes:
     def execute(self, verbose=False):
         if verbose: print('Running '+self.name)
         # Loop through and create plots
-        for plane in self.yamldictlist:
+        for iplane, plane in enumerate(self.yamldictlist):
             tavg     = plane['tavg']
             ncfile   = plane['ncfile']
             group    = plane['group']
@@ -117,8 +117,8 @@ avgplanes:
                 if action.required and (action.actionname not in self.yamldictlist[0].keys()):
                     # This is a problem, stop things
                     raise ValueError('Required action %s not present'%action.actionname)
-                if action.actionname in self.yamldictlist[0].keys():
-                    actionitem = action(self, self.yamldictlist[0][action.actionname])
+                if action.actionname in self.yamldictlist[iplane].keys():
+                    actionitem = action(self, self.yamldictlist[iplane][action.actionname])
                     actionitem.execute()
         return 
 


### PR DESCRIPTION
This fixes a bug in the loop over subactions in the executor.  If there are multiple items for an executor to work on, each item can have its own list of actions.  However, they need to refer to the right list of subaction items.  For example, if you have 
```yaml
averageplanes:
- name: item1
  [ ... ]
  plot:
    title: "Title 1" 
- name: item2
  [ ... ]
  plot:
    title: "Title 2" 
```
This will make sure that the plot parameters for item2 are not read from item1.

@gyalla, this bug might also exit in the other executors too, not sure if you saw that.