### PR TITLE
Remove unneeded import in spod executor

### DIFF
--- a/postproengine/spod.py
+++ b/postproengine/spod.py
@@ -19,7 +19,6 @@ import numpy as np
 import scipy as sp
 import matplotlib
 import matplotlib.pyplot as plt
-import amrwind_frontend as amrwind
 from itertools import product
 
 def plot_radial(Ur,theta,r,rfact=1.4,cmap='coolwarm',newfig=True,vmin=None,vmax=None,ax=None):


### PR DESCRIPTION
@gyalla -- this is a really minor thing, but it looks like the spod executor might not need to load the `amrwind_frontend` library.  

One thing I'm trying to do is to keep the postprocessing engine as lightweight as possible.  If we import `amrwind_frontend` it actually will also pull in lots of things like `TkInter`, and other things which require X-window capabilities, etc.  (This is partly a bad original design by my fault, I should have made it more modular and only load in required libraries.)

However, if we do need to read in amr-wind input files for the executor, we can definitely still keep this here.

Lawrence