### PR TITLE
Upgrade averageplanes to handle file globbing

### DIFF
--- a/postproamrwindsample_xarray.py
+++ b/postproamrwindsample_xarray.py
@@ -13,16 +13,16 @@ nonan = lambda x, doreplace: np.nan_to_num(x) if doreplace else x
 
 def getFileList(ncfileinput):
     ncfilelist = []
-    if type(ncfileinput) is str:
-        ncfilelist=list(glob.glob(ncfileinput))
-    elif type(ncfileinput) is not list:
+    if isinstance(ncfileinput, str):
+        ncfilelist=list(sorted(glob.glob(ncfileinput)))
+    elif not isinstance(ncfileinput, list):
         for ncfileiter, ncfile in enumerate(ncfileinput):
-            files = glob.glob(ncfile[ncfileiter])
+            files = sorted(glob.glob(ncfile[ncfileiter]))
             for file in files:
                 ncfilelist.append(file)
     else:
         for ncfileiter, ncfile in enumerate(ncfileinput):
-            files = glob.glob(ncfile)
+            files = sorted(glob.glob(ncfile))
             for file in files:
                 ncfilelist.append(file)
 
@@ -252,10 +252,7 @@ def avgPlaneXR(ncfileinput, timerange,
     Compute the average of ncfile variables
     """
     # make sure input is a list
-    if not isinstance(ncfileinput, list):
-        ncfilelist = [ncfileinput]
-    else:
-        ncfilelist = ncfileinput
+    ncfilelist = getFileList(ncfileinput)
     ncfile=ncfilelist[0]
     suf='_avg'
     # Create a fresh db dictionary

--- a/postproengine/averageplanes.py
+++ b/postproengine/averageplanes.py
@@ -15,6 +15,7 @@ import pickle
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from postproengine import interpolatetemplate, circavgtemplate
+from postproengine import compute_axis1axis2_coords
 
 """
 Plugin for post processing averaged planes
@@ -91,10 +92,13 @@ avgplanes:
             loadpkl  = plane['loadpklfile']            
             pklfile  = plane['savepklfile']
             varnames = plane['varnames']
-            #Get all times if not specified 
-            filelist = []
-            for fileiter in range(0,len(ncfile)):
-                filelist.append(ncfile[fileiter])
+            #Get all times if not specified
+            if isinstance(ncfile, str):
+                filelist = [ncfile]
+            else:
+                filelist = []
+                for fileiter in range(0,len(ncfile)):
+                    filelist.append(ncfile[fileiter])
 
             if tavg==[]:
                 for fileiter, file in enumerate(filelist):
@@ -292,6 +296,13 @@ avgplanes:
             title    = self.actiondict['title']
             plotfunc = eval(self.actiondict['plotfunc'])
             if not isinstance(iplanes, list): iplanes = [iplanes,]
+
+            # Convert to native axis1/axis2 coordinates if necessary
+            if ('a1' in [xaxis, yaxis]) or \
+               ('a2' in [xaxis, yaxis]) or \
+               ('a3' in [xaxis, yaxis]):
+                compute_axis1axis2_coords(self.parent.dbavg)
+            
             for iplane in iplanes:
                 fig, ax = plt.subplots(1,1,figsize=(figsize[0],figsize[1]), dpi=dpi)
                 plotq = plotfunc(self.parent.dbavg['velocityx_avg'], self.parent.dbavg['velocityy_avg'], self.parent.dbavg['velocityz_avg'])


### PR DESCRIPTION
Made some changes related to averaging postpro planes:
- minor edits to getFileList()
- upgrade avgPlaneXR() to handle file globbing
- enable plots in averageplanes executor to handle plotting in axis1/2/3 coordinates.

Note: use `isinstance(var, type)` to determine file types -- it's a slightly safer way to check types in python.

Also tagging @gyalla in case you happen to be looking at something similar in your PR.  Feel free to change and edit as necessary. 