### PR TITLE
Radial reynolds shear stress bug fix + initial SPOD decomposition of the radial reynolds stress

### DIFF
--- a/postproamrwindsample_xarray.py
+++ b/postproamrwindsample_xarray.py
@@ -366,10 +366,6 @@ def avgPlaneXR(ncfileinput, timerange,
         R=get_mapping_xyz_to_axis1axis2(db['axis1'],db['axis2'],db['axis3'],rot=axis_rotation)
         #if not np.array_equal(R,np.eye(R.shape[0])):
         db['velocitya1_avg'],db['velocitya2_avg'],db['velocitya3_avg'] = apply_coordinate_transform(R,db['velocityx_avg'],db['velocityy_avg'],db['velocityz_avg'])
-    else:
-        db['velocitya1_avg'] = db['velocityx_avg']
-        db['velocitya2_avg'] = db['velocityy_avg']
-        db['velocitya3_avg'] = db['velocityz_avg']
 
     if verbose:
         print("Ncount = %i"%Ncount)
@@ -578,13 +574,13 @@ def ReynoldsStress_PlaneXR(ncfileinput, timerange,
     if avgdb is None:
         if verbose: print("Calculating averages")
 
+        orig_varnames = varnames[:]
         db = avgPlaneXR(ncfilelist, timerange,
                         extrafuncs=extrafuncs,
-                        varnames=varnames,
+                        varnames=orig_varnames,
                         groupname=groupname, verbose=verbose, includeattr=includeattr,axis_rotation=axis_rotation)
     else:
         db.update(avgdb)
-
 
     group   = db['group']
     Ncount = 0    

--- a/postproengine/__init__.py
+++ b/postproengine/__init__.py
@@ -393,10 +393,13 @@ def get_mapping_xyz_to_axis1axis2(axis1,axis2,axis3,rot=0):
     ])
     n1 = axis1/np.linalg.norm(axis1)
     n2 = axis2/np.linalg.norm(axis2)
+
     if np.linalg.norm(axis3) > 0.0:
         n3 = axis3/np.linalg.norm(axis3)
     else:
-        n3 = axis3
+        #n3 = axis3
+        n3 = np.cross(n1, n2)
+        n3 /= np.linalg.norm(n3)
 
     R = np.array([n1,n2,n3])
     R = Rtheta @ R

--- a/postproengine/doc/convert.md
+++ b/postproengine/doc/convert.md
@@ -12,10 +12,11 @@ Converts netcdf sample planes to different file formats
 ```
   bts                 : ACTION: Converts data to bts files (Optional)
     iplane            : Index of x location to read (Required)
-    yhh               : Hub height location in y (Required)
-    zhh               : Hub height location in z (Required)
+    yhh               : Location in flow to use as hub height location in y (Required)
+    zhh               : Location in flow to use as hub height location in z (Required)
     btsfile           : bts file name to save results (Required)
     ID                : bts file ID. 8="periodic", 7="non-periodic" (Optional, Default: 8)
+    turbine_height    : Height of the turbine (if different than zc) (Optional, Default: None)
     group             : Which group to pull from netcdf file (Optional, Default: None)
   nalu_to_amr         : ACTION: Converts a list of planes from Nalu-Wind to AMR-Wind (Optional)
     savefile          : Name of AMR-Wind file (Required)

--- a/postproengine/doc/spod.md
+++ b/postproengine/doc/spod.md
@@ -7,7 +7,7 @@ Compute SPOD eigenvectors and eigenvalues
   ncfile              : NetCDF sampling file (Required)
   trange              : Which times to average over (Optional, Default: [])
   group               : Which group to pull from netcdf file (Optional, Default: None)
-  nperseg             : Number of snapshots per segment to specify number of blocks. (Required)
+  nperseg             : Number of snapshots per segment to specify number of blocks. Default is 1 block. (Optional, Default: None)
   xc                  : Wake center on xaxis (Optional, Default: None)
   yc                  : Wake center on yaxis (Optional, Default: None)
   xaxis               : Which axis to use on the abscissa (Optional, Default: 'y')
@@ -22,7 +22,7 @@ Compute SPOD eigenvectors and eigenvalues
   correlations        : List of correlations to include in SPOD. Separate U,V,W components with dash. Examples: U-V-W, U,V,W,V-W  (Optional, Default: ['U'])
   output_dir          : Directory to save results (Optional, Default: './')
   savepklfile         : Name of pickle file to save results (Optional, Default: '')
-  loadpklfile         : Name of pickle file to load to perform actions (Optional, Default: '')
+  loadpklfile         : Name of pickle file to load to perform actions (Optional, Default: None)
   compute_eigen_vectors: Boolean to compute eigenvectors or just eigenvalues (Optional, Default: True)
   sort                : Boolean to included sorted wavenumber and frequency indices by eigenvalue (Optional, Default: True)
   save_num_modes      : Number of eigenmodes to save, ordered by eigenvalue. Modes will be save in array of shape (save_num_mods,NR). (Optional, Default: None)
@@ -51,6 +51,10 @@ Compute SPOD eigenvectors and eigenvalues
     Uinf              : Velocity for compute strouhal frequency (Optional, Default: 0)
     St                : Plot leading eigenmodes at fixed Strouhal frequency (Optional, Default: None)
     itime             : Time iteration to plot (Optional, Default: 0)
+  radial_shear_stress_flux: ACTION: Compute radial shear stress flux contribution from streamwise SPOD modes (Optional)
+    num               : Number of eigenvectors to include in reconstruction (Optional, Default: 1)
+    savefile          : Filename to save results (Optional, Default: '')
+    correlations      : List of correlations (Optional, Default: ['U'])
 ```
 
 ## Example

--- a/postproengine/doc/wake_meander.md
+++ b/postproengine/doc/wake_meander.md
@@ -7,6 +7,7 @@ Compute wake meandering statistics
   name                : An arbitrary name (Required)
   ncfile              : NetCDF sampling files of cross-flow planes (Required)
   group               : Which group to pull from netcdf file (Optional, Default: None)
+  savepklfile         : Name of pickle file to save wake object (Optional, Default: '')
   varnames            : Variables to extract from the netcdf file (Optional, Default: ['velocityx', 'velocityy', 'velocityz'])
   trange              : Which times to postprocess (Required)
   yhub                : Lateral hub-height center (Optional, Default: None)

--- a/postproengine/reynoldsstress.py
+++ b/postproengine/reynoldsstress.py
@@ -223,7 +223,7 @@ reynoldsstress:
 
                 Theta = np.arctan2(ZZ-z_center,YY-y_center)
 
-                self.parent.dbReAvg['uxur_avg'][iplane,:,:] = uv_avg * np.sin(Theta) + uw_avg * np.cos(Theta)
+                self.parent.dbReAvg['uxur_avg'][iplane,:,:] = uv_avg * np.cos(Theta) + uw_avg * np.sin(Theta)
 
             # Overwrite picklefile
             if len(self.parent.pklfile)>0:

--- a/postproengine/spod.py
+++ b/postproengine/spod.py
@@ -130,18 +130,18 @@ def reconstruct_flow_istfft(inds,numSteps,dt,nperseg,overlap,sorted_inds,variabl
             proj_coeff  = POD_proj_coeff[corr][ktheta_ind,angfreq_ind,block_ind] #projection of u onto POD mode
             mode_rhat[:,ktheta_ind,angfreq_ind,:] += proj_coeff*POD_modes[corr][:,ktheta_ind,angfreq_ind,block_ind,:] #reconstruction of fourier mode by the ith POD mode
 
-        #fourier transform in theta 
-        mode_r_that = np.fft.ifft(mode_rhat,axis=1) 
-        
-        mode_r = np.zeros((NR,NTheta,numSteps,shape[-1]),dtype=complex) 
-        if components==None: components = range(mode_r_that.shape[-1])
-        for r in range(mode_r_that.shape[0]):
-            for theta in range(mode_r_that.shape[1]):
-                for comp in components:
-                    Zxx = np.zeros((len(angfreq),Nblocks),dtype=complex)
-                    Zxx[angfreq_ind,:] = mode_r_that[r,theta,angfreq_ind,comp]
-                    t, real_signal = compute_istft(Zxx,fs=1.0/dt,nperseg=nperseg,noverlap=overlap,window='hann')
-                    mode_r[r,theta,:,comp] = real_signal[:numSteps]
+    #fourier transform in theta 
+    mode_r_that = np.fft.ifft(mode_rhat,axis=1) 
+    mode_r = np.zeros((NR,NTheta,numSteps,shape[-1])) 
+    if components==None: components = range(mode_r_that.shape[-1])
+    for r in range(mode_r_that.shape[0]):
+        for theta in range(mode_r_that.shape[1]):
+            for comp in components:
+                Zxx = np.zeros((len(angfreq),Nblocks),dtype=complex)
+                Zxx[angfreq_ind,:] = mode_r_that[r,theta,angfreq_ind,comp]
+                t, real_signal = compute_istft(Zxx,fs=1.0/dt,nperseg=nperseg,noverlap=overlap,window='hann')
+                mode_r[r,theta,:,comp] = real_signal[:numSteps]
+
     return mode_r
 
 
@@ -577,13 +577,13 @@ spod:
                 if self.verbose:
                     print("--> Reading in velocity data (iplane="+str(iplane)+")")
                 udata_cart,xc,y,z,self.times = read_cart_data(ncfile,self.varnames,group,self.trange,iplane,self.xaxis,self.yaxis)
-                #file = 'ucart_data.pkl'
-                #with open(file,'wb') as f:
-                #    pickle.dump(udata_cart,f)
-                #    pickle.dump(xc,f)
-                #    pickle.dump(y,f)
-                #    pickle.dump(z,f)
-                #    pickle.dump(self.times,f)
+                file = 'ucart_data.pkl'
+                with open(file,'wb') as f:
+                    pickle.dump(udata_cart,f)
+                    pickle.dump(xc,f)
+                    pickle.dump(y,f)
+                    pickle.dump(z,f)
+                    pickle.dump(self.times,f)
                 #with open(file, 'rb') as f:
                 #    udata_cart = pickle.load(f)
                 #    xc = pickle.load(f)
@@ -1063,10 +1063,10 @@ spod:
             NTheta  = len(self.parent.variables['theta'])
             NR      = len(self.parent.variables['r'])
             angfreq = self.parent.variables['angfreq'] #angular frequencies for each block 
-            angfreq_full = 2*np.pi*np.fft.rfftfreq(numSteps,self.parent.times[1]-self.parent.times[0]) #angular frequencies for full time window
 
             db = {corr: {} for corr in correlations}
             db_velxr = {} 
+
             ### Compute time averaged streamwise velocity 
             velocityx_avg  = np.mean(self.parent.udata_polar[:,:,:,0],axis=2)
 

--- a/postproengine/spod.py
+++ b/postproengine/spod.py
@@ -234,8 +234,8 @@ class postpro_spod():
             'help':'Which times to average over', }, 
         {'key':'group',   'required':False,  'default':None,
          'help':'Which group to pull from netcdf file', },
-        {'key':'nperseg',   'required':True,  'default':256,
-         'help':'Number of snapshots per segment to specify number of blocks.', },
+        {'key':'nperseg',   'required':False,  'default':None,
+         'help':'Number of snapshots per segment to specify number of blocks. Default is 1 block.', },
         {'key':'xc',   'required':False,  'default':None,
          'help':'Wake center on xaxis', },
         {'key':'yc',   'required':False,  'default':None,
@@ -434,6 +434,9 @@ spod:
                             udata_polar[:,:,titer,1] = v_vel * np.cos(TT) + w_vel * np.sin(TT)
                             udata_polar[:,:,titer,2] = -v_vel * np.sin(TT) + w_vel * np.cos(TT)
 
+                    if nperseg==None:
+                        nperseg = len(times)
+                        print("nperseg: ",nperseg)
                     Nkt = int(nperseg/2) + 1
                     time_segments = np.array([times[i:i+nperseg] for i in range(0,len(times)-nperseg+1,nperseg-nperseg//2)])
                     dt = times[1]-times[0]
@@ -551,7 +554,9 @@ spod:
                         self.variables['theta']    = theta
                         self.variables['y']        = y
                         self.variables['z']        = z
-                        self.variables['x']        = x
+                        self.variables['x']        = xc
+                        self.variables['ycenter']  = ycenter
+                        self.variables['zcenter']  = zcenter
                         if not os.path.exists(self.output_dir):
                             os.makedirs(self.output_dir)
                         savefname = savefile.format(iplane=iplane)

--- a/postproengine/wake_meandering.py
+++ b/postproengine/wake_meandering.py
@@ -80,6 +80,8 @@ class postpro_wakemeander():
         'help':'NetCDF sampling files of cross-flow planes', },
         {'key':'group',   'required':False,  'default':None,
          'help':'Which group to pull from netcdf file', },
+        {'key':'savepklfile', 'required':False,  'default':'',
+        'help':'Name of pickle file to save wake object', },
         {'key':'varnames',  'required':False,  'default':['velocityx', 'velocityy', 'velocityz'],
          'help':'Variables to extract from the netcdf file',},        
         {'key':'trange',    'required':True,  'default':[0,1],
@@ -188,6 +190,7 @@ class postpro_wakemeander():
             self.varnames = entry['varnames']
             self.output_dir =  entry['output_dir']
             self.axis_rotation = entry['axis_rotation']
+            savepklfile  = entry['savepklfile']
 
             if not isinstance(iplanes, list): iplanes = [iplanes,]
             #Get all times if not specified 
@@ -291,6 +294,11 @@ class postpro_wakemeander():
                     savefname = savefile.format(iplane=self.iplane)
                     savefname = os.path.join(self.output_dir, savefname)
                     self.dfcenters.to_csv(savefname,index=False,sep=',')
+
+                if len(savepklfile)>0:
+                    savefname = os.path.join(self.output_dir, savepklfile)
+                    with open(savefname, 'wb') as f:
+                        pickle.dump(self.wake, f)
 
                 # Do any sub-actions required for this task
                 for a in self.actionlist:


### PR DESCRIPTION
Adding initial action to SPOD executor to compute contribution to radial shear stress flux from each streamwise POD mode, namely:

ux_avg * [ ifft(a_j \psi_j) ur']_avg

where \psi_j is the jth streamwise POD mode and a_j is the project of u onto \psi_j

Other executor updates include: 

-     Fixing bug in spod executor to correctly store the x location of the cross flow plane and subtract temporal mean
-     Adding option to store wake objects for more efficient plotting in wake meandering executor
-     Updated bts converter executor to allow for lateral and vertical offsets. **Functionality could be further generalized via interpolation**
-     Fixing bug in the computation of the radial reynolds shear stress
