### PR TITLE
Added postplotfunc options to multiple executors/actions

### DIFF
--- a/postproengine/__init__.py
+++ b/postproengine/__init__.py
@@ -690,7 +690,9 @@ class contourplottemplate():
         {'key':'plotfunc',  'required':False,  'default':'lambda db: 0.5*(db["uu_avg"]+db["vv_avg"]+db["ww_avg"])',
          'help':'Function to plot (lambda expression)',},
         {'key':'axis_rotation',  'required':False,  'default':0,
-         'help':'Degrees to rotate a1,a2,a3 axis for plotting.',},                
+         'help':'Degrees to rotate a1,a2,a3 axis for plotting.',},
+        {'key':'postplotfunc', 'required':False,  'default':'',
+         'help':'Function to call after plot is created. Function should have arguments func(fig, ax)',},
     ]
     plotdb = None
     def __init__(self, parent, inputs):
@@ -714,6 +716,8 @@ class contourplottemplate():
         title    = self.actiondict['title']
         plotfunc = eval(self.actiondict['plotfunc'])
         axis_rotation = self.actiondict['axis_rotation']
+        postplotfunc = plotitem['postplotfunc']
+
         if not isinstance(iplanes, list): iplanes = [iplanes,]
 
         # Convert to native axis1/axis2 coordinates if necessary
@@ -736,6 +740,13 @@ class contourplottemplate():
             ax.set_ylabel(ylabel)
             ax.axis('scaled')
             ax.set_title(eval("f'{}'".format(title)))
+
+            # Run any post plot functions
+            if len(postplotfunc)>0:
+                modname = postplotfunc.split('.')[0]
+                funcname = postplotfunc.split('.')[1]
+                func = getattr(sys.modules[modname], funcname)
+                func(fig, ax)
 
             if len(savefile)>0:
                 savefname = savefile.format(iplane=iplane)

--- a/postproengine/doc/avgplanes.md
+++ b/postproengine/doc/avgplanes.md
@@ -43,6 +43,7 @@ Average netcdf sample planes
     title             : Title of the plot (Optional, Default: '')
     plotfunc          : Function to plot (lambda expression) (Optional, Default: 'lambda db: 0.5*(db["uu_avg"]+db["vv_avg"]+db["ww_avg"])')
     axis_rotation     : Degrees to rotate a1,a2,a3 axis for plotting. (Optional, Default: 0)
+    postplotfunc      : Function to call after plot is created. Function should have arguments func(fig, ax) (Optional, Default: '')
   interpolate         : ACTION: Interpolate data from an arbitrary set of points (Optional)
     pointlocationfunction: Function to call to generate point locations. Function should have no arguments and return a list of points (Required)
     pointcoordsystem  : Coordinate system for point interpolation.  Options: XYZ, A1A2 (Required)

--- a/postproengine/doc/instantaneousplanes.md
+++ b/postproengine/doc/instantaneousplanes.md
@@ -14,13 +14,14 @@ Make instantaneous plots from netcdf sample planes
   group               : Which group to pull from netcdf file (Optional, Default: None)
   title               : Title of the plot (Optional, Default: '')
   varnames            : Variables to extract from the netcdf file (Optional, Default: ['velocityx', 'velocityy', 'velocityz'])
-  plotfunc            : Function to plot (lambda expression) (Optional, Default: 'lambda u, v, w: np.sqrt(u**2 + v**2)')
+  plotfunc            : Function to plot (lambda expression) (Optional, Default: "lambda db,i: np.sqrt(db['velocityx'][i]**2 + db['velocityy'][i]**2)")
   clevels             : Color levels (eval expression) (Optional, Default: 'np.linspace(0, 12, 121)')
   xlabel              : Label on the X-axis (Optional, Default: 'X [m]')
   ylabel              : Label on the Y-axis (Optional, Default: 'Y [m]')
   dpi                 : Figure resolution (Optional, Default: 125)
   figsize             : Figure size (inches) (Optional, Default: [12, 3])
   savefile            : Filename to save the picture (Optional, Default: '')
+  postplotfunc        : Function to call after plot is created. Function should have arguments func(fig, ax) (Optional, Default: '')
 ```
 
 ## Actions: 

--- a/postproengine/doc/reynoldsstress.md
+++ b/postproengine/doc/reynoldsstress.md
@@ -38,6 +38,7 @@ Reynolds-Stress average netcdf sample planes
     title             : Title of the plot (Optional, Default: '')
     plotfunc          : Function to plot (lambda expression) (Optional, Default: 'lambda db: 0.5*(db["uu_avg"]+db["vv_avg"]+db["ww_avg"])')
     axis_rotation     : Degrees to rotate a1,a2,a3 axis for plotting. (Optional, Default: 0)
+    postplotfunc      : Function to call after plot is created. Function should have arguments func(fig, ax) (Optional, Default: '')
   interpolate         : ACTION: Interpolate data from an arbitrary set of points (Optional)
     pointlocationfunction: Function to call to generate point locations. Function should have no arguments and return a list of points (Required)
     pointcoordsystem  : Coordinate system for point interpolation.  Options: XYZ, A1A2 (Required)

--- a/postproengine/doc/spod.md
+++ b/postproengine/doc/spod.md
@@ -55,6 +55,8 @@ Compute SPOD eigenvectors and eigenvalues
     num               : Number of eigenvectors to include in reconstruction (Optional, Default: 1)
     savefile          : Filename to save results (Optional, Default: '')
     correlations      : List of correlations (Optional, Default: ['U'])
+    store_fluc        : Boolean to store fluctuating fields (Optional, Default: False)
+    components        : List of component to include in reconstructions (default is all) (Optional, Default: None)
 ```
 
 ## Example


### PR DESCRIPTION
Some minor updates:
- Added the `postplotfunc` option to `contourplottemplate()`.  This affects downstream executors like avgplanes and reynoldsstress.
- Added `postplotfunc` option to `instantaneousplanes`
- Changed the default function signature for `plotfunc` in `instantaneousplanes`.

Note to @gyalla:
This PR will break earlier notebooks which used instantaneousplanes (you might have used this executor before).  The new lambda functions should look something like this:
```yaml
  plotfunc: "lambda db, i: db['temperature'][i]"
```
This was necessary because earlier I could only plot velocities, but now it is more general.

**Also a general note regarding `postplotfunc`**:
We don't have to use the `udfmodules` keyword to import user defined modules.  If you're lazy like me, you can do this all within one python script, and not have to create a separate python script just for importing.   The way to do this is by defining the function like this:
```python
import postproengine as ppeng
def postplot(fig, ax):
    ax.grid(ls=':',lw=0.5)
    ax.set_title('NEW TITLE')
    return
```

Then adding attaching to an existing module.  In our case `postproengine` will be always available because that's how we're running any of this.
```python
ppeng.postplot = postplot
```
Now you can refer to it in `postplotfunc` like this:
```yaml
  postplotfunc: postproengine.postplot
```


 