### PR TITLE
Remove plt.close() from instantaneousplanes.py

### DIFF
--- a/postproengine/instantaneousplanes.py
+++ b/postproengine/instantaneousplanes.py
@@ -247,7 +247,6 @@ instantaneousplanes:
                     directory += '/'
                     os.makedirs(directory, exist_ok=True)
                     plt.savefig(savefname)
-                plt.close()
         
 
     # --- Inner classes for action list ---
@@ -409,4 +408,4 @@ instantaneousplanes:
                     directory += '/'
                     os.makedirs(directory, exist_ok=True)
                     plt.savefig(savefname)
-                plt.close()
+


### PR DESCRIPTION
hi @gyalla,

One thing I noticed in the `instantaenousplanes.py` is that if `plt.close()` is called, the plots don't come up if we use it in a jupyter notebook (even if `%matplotlib inline` is there).  Is it okay if we remove the close() call from the actions?  Would it affect how you generate the plots?

Lawrence