### PR TITLE
Upgrade plotting in contourplottemplate()

### DIFF
--- a/postproengine/instantaneousplanes.py
+++ b/postproengine/instantaneousplanes.py
@@ -193,6 +193,15 @@ instantaneousplanes:
             'help':'Filename to save the picture', },
             {'key':'postplotfunc', 'required':False,  'default':'',
             'help':'Function to call after plot is created. Function should have arguments func(fig, ax)',},
+            {'key':'xscalefunc',  'required':False,  'default':'lambda x: x',
+             'help':'Function to scale the x-axis (lambda expression)',},
+            {'key':'yscalefunc',  'required':False,  'default':'lambda y: y',
+             'help':'Function to scale the y-axis (lambda expression)',},
+            {'key':'figname',    'required':False,  'default':None,
+             'help':'Name/number of figure to create plot in'},
+            {'key':'axesnumfunc',    'required':False,  'default':None,
+             'help':'Function to determine which subplot axes to create plot in (lambda expression with iplane as arg)'},
+
         ]
         def __init__(self, parent, inputs):
             self.actiondict = mergedicts(inputs, self.actiondefs)
@@ -214,24 +223,35 @@ instantaneousplanes:
             figsize  = self.actiondict['figsize']
             fontsize = self.actiondict['fontsize']
             postplotfunc = self.actiondict['postplotfunc']
+            xscalef  = eval(self.actiondict['xscalefunc'])
+            yscalef  = eval(self.actiondict['yscalefunc'])
+            figname  = self.actiondict['figname']
+            axesnumf = None if self.actiondict['axesnumfunc'] is None else eval(self.actiondict['axesnumfunc'])
 
             # Loop through each time instance and plot
             iplane = self.parent.iplane
             for iplot, i in enumerate(self.parent.iters):
                 time  = self.parent.db['times'][iplot]
-                fig, ax = plt.subplots(1,1,figsize=(figsize[0],figsize[1]), dpi=dpi)
+                if (figname is not None) and (axesnumf is not None):
+                    fig     = plt.figure(figname)
+                    allaxes = fig.get_axes()
+                    iax     = axesnumf(iplane)
+                    ax      = allaxes[iax]
+                else:
+                    fig, ax = plt.subplots(1,1,figsize=(figsize[0],figsize[1]), dpi=dpi)
                 plotq = plotfunc(self.parent.db, i)
-                c=plt.contourf(self.parent.db[self.parent.xaxis][iplane,:,:], self.parent.db[self.parent.yaxis][iplane,:,:], plotq[iplane, :, :], levels=clevels, cmap=cmap, extend='both')
+                c = ax.contourf(xscalef(self.parent.db[self.parent.xaxis][iplane,:,:]),
+                                yscalef(self.parent.db[self.parent.yaxis][iplane,:,:]),
+                                plotq[iplane, :, :], levels=clevels, cmap=cmap, extend='both')
                 if cbar_inc:
                     divider = make_axes_locatable(ax)
                     cax = divider.append_axes("right", size="3%", pad=0.05)
                     cbar=fig.colorbar(c, ax=ax, cax=cax)
                     cbar.ax.tick_params(labelsize=fontsize)
-                
-                ax.set_xlabel(xlabel,fontsize=fontsize)
-                ax.set_ylabel(ylabel,fontsize=fontsize)
+                if (xlabel is not None): ax.set_xlabel(xlabel,fontsize=fontsize)
+                if (ylabel is not None): ax.set_ylabel(ylabel,fontsize=fontsize)
                 ax.tick_params(axis='both', which='major', labelsize=fontsize) 
-                ax.set_title(eval("f'{}'".format(title)),fontsize=fontsize)
+                ax.set_title(eval("rf'{}'".format(title)),fontsize=fontsize)
                 ax.axis('scaled')
 
                 # Run any post plot functions


### PR DESCRIPTION
Added some additional plotting functionality to the `contourplottemplate()`:
- Added `xscalefunc` and `yscalefunc` as optional inputs.  These inputs can be used to scale the x and y-axis.  As an example, adding something like this
```yaml
xscalefunc: 'lambda x: (x-2280.0)/240.0'
```
will make the x-axis centered at the rotor and put in units of diameter 

- Made it possible to _not_ label the x and y-axes if `ylabel` or `xlabel` is left blank.
- Added limited ability to include latex in the plot titles.
- Added ability to create the figure and subplots outside of the postproengine, and then assign each figure to a particular figure/subplot.  This is done using the `figname` and `axesnumfunc` inputs.  We can use them like this:
```yaml
    contourplot: 
      figname: fig1
      axesnumfunc: 'lambda i: 1'
```
then before executing the driver, set up the figure and axes like this:
```python
fig, axs = plt.subplots(4,1, figsize=(12,8), sharex=True, num="fig1", dpi=150)
ppeng.driver(yamldict)
```
This will put the contour plot in subplot 2 of fig1.

Note @gyalla, the use of latex in the plot title isn't perfect yet, you can do something like:
```
 title: 'Baseline TKE $m^2/s^2$'
```
but things involving braces are still problematic because it the f-string evaluation can't be handled properly.
