### PR TITLE
Offset vector to replace normal in plane sampler

### DIFF
--- a/amrwind_frontend.py
+++ b/amrwind_frontend.py
@@ -273,7 +273,7 @@ class MyApp(tkyg.App, object):
 
     def writeAMRWindInput(self, filename, verbose=False, 
                           postloadctrlelem=True,
-                          outputextraparams=True, comments=True):
+                          outputextraparams=True, comments=True,amr_wind_version='latest'):
         """
         Write out the input file for AMR-Wind
         TODO: Do more sophisticated output control later
@@ -304,12 +304,29 @@ class MyApp(tkyg.App, object):
         actuatordict= self.listboxpopupwindict['listboxactuator'].dumpdict('AMR-Wind', keyfunc=samplingkey)
 
         if verbose: print('dumping listboxpostprosetup')
+
         def postprocessingkey(n, d1, d2):
             if ('outputprefix' in d2.outputdef):
                 return n+'.'+d2.outputdef['AMR-Wind']
             else:
                 return d1['outputprefix']['AMR-Wind']+'.'+n+'.'+d2.outputdef['AMR-Wind']
         postprocessingdict= self.listboxpopupwindict['listboxpostprosetup'].dumpdict('AMR-Wind', keyfunc=postprocessingkey)
+
+        """
+        AMR_WIND version specific modification to dicts 
+        """
+        def remove_entries(data_dict, str_to_remove, how='in'):
+            if how=='in':
+                keys_to_remove = [key for key in data_dict if str_to_remove in key]
+            elif how=='endswith':
+                keys_to_remove = [key for key in data_dict if key.endswith(str_to_remove)]
+            # Remove the keys from the dictionary
+            for key in keys_to_remove:
+                del data_dict[key]
+        if amr_wind_version == 'latest':
+            remove_entries(sampledict,'.normal',how='endswith')
+        elif amr_wind_version == 'legacy':
+            remove_entries(sampledict,'.offset_vector',how='endswith')
 
         # Construct the output dict
         outputdict=inputdict.copy()

--- a/config.yaml
+++ b/config.yaml
@@ -3082,14 +3082,6 @@ popupwindow:
       row:        6
       outputdef:
         AMR-Wind: axis2    
-    - name:       sampling_p_normal
-      label:      Plane normal
-      inputtype:  [float, float, float]
-      defaultval: [0, 0, 0]
-      frame:      sample_plane_frame
-      row:        7
-      outputdef:
-        AMR-Wind: normal
     - name:       sampling_p_offset_vector
       label:      Plane offset_vector
       inputtype:  [float, float, float]
@@ -3098,6 +3090,14 @@ popupwindow:
       row:        8
       outputdef:
         AMR-Wind: offset_vector
+    - name:       sampling_p_normal
+      label:      Plane normal
+      inputtype:  [float, float, float]
+      defaultval: [0, 0, 0]
+      frame:      sample_plane_frame
+      row:        7
+      outputdef:
+        AMR-Wind: normal
     - name:       sampling_p_offsets
       label:      "Plane offsets   "
       inputtype:  str

--- a/config.yaml
+++ b/config.yaml
@@ -2957,6 +2957,8 @@ popupwindow:
           activewhen: ['PlaneSampler', 1]
         - input:  sampling_p_normal
           activewhen: ['PlaneSampler', 1]
+        - input:  sampling_p_offset_vector
+          activewhen: ['PlaneSampler', 1]
         - input:  sampling_p_offsets
           activewhen: ['PlaneSampler', 1]
         - input:  sampling_lidar_num_points
@@ -3088,6 +3090,14 @@ popupwindow:
       row:        7
       outputdef:
         AMR-Wind: normal
+    - name:       sampling_p_offset_vector
+      label:      Plane offset_vector
+      inputtype:  [float, float, float]
+      defaultval: [0, 0, 0]
+      frame:      sample_plane_frame
+      row:        8
+      outputdef:
+        AMR-Wind: offset_vector
     - name:       sampling_p_offsets
       label:      "Plane offsets   "
       inputtype:  str

--- a/farmfunctions.py
+++ b/farmfunctions.py
@@ -970,7 +970,8 @@ def sampling_createDictForTurbine(self, turbname, tdict, pdict, defaultopt):
             downstream = scale*float(pdict['downstream'])        
             offsetvec  = np.linspace(0, upstream+downstream, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
-            sampledict['sampling_p_offset_vector']  = streamwise
+            sampledict['sampling_p_normal']  = streamwise
+            sampledict['sampling_p_offset_vector'] = streamwise
             sampledict['sampling_p_offsets'] = offsetstr
     # --- Create hub-height sampling planes --- 
     elif probetype == 'hubheight':
@@ -1009,6 +1010,7 @@ def sampling_createDictForTurbine(self, turbname, tdict, pdict, defaultopt):
             above      = scale*float(pdict['above'])
             offsetvec  = np.linspace(0, above+below, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
+            sampledict['sampling_p_normal']  = vert
             sampledict['sampling_p_offset_vector']  = vert
             sampledict['sampling_p_offsets'] = offsetstr
     # --- Create streamwise sampling planes --- 
@@ -1047,6 +1049,7 @@ def sampling_createDictForTurbine(self, turbname, tdict, pdict, defaultopt):
             lateral    = scale*float(pdict['lateral'])
             offsetvec  = np.linspace(0, lateral, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
+            sampledict['sampling_p_normal']  = crossstream
             sampledict['sampling_p_offset_vector']  = crossstream
             sampledict['sampling_p_offsets'] = offsetstr        
     else:
@@ -1222,6 +1225,7 @@ def sampling_createDictForFarm(self, pdict, AvgCenter,
             above      = scale*float(pdict['above'])
             offsetvec  = np.linspace(0, above+below, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
+            sampledict['sampling_p_normal']  = vert
             sampledict['sampling_p_offset_vector']  = vert
             sampledict['sampling_p_offsets'] = offsetstr
     # --- Create rotorplane sampling plane --- 
@@ -1260,6 +1264,7 @@ def sampling_createDictForFarm(self, pdict, AvgCenter,
             downstream = scale*float(pdict['downstream'])        
             offsetvec  = np.linspace(0, upstream+downstream, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
+            sampledict['sampling_p_normal']  = streamwise
             sampledict['sampling_p_offset_vector']  = streamwise
             sampledict['sampling_p_offsets'] = offsetstr
 
@@ -1309,6 +1314,7 @@ def sampling_createDictForFarm(self, pdict, AvgCenter,
             lateral    = scale*float(pdict['lateral'])
             offsetvec  = np.linspace(0, lateral, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
+            sampledict['sampling_p_normal']  = crossstream
             sampledict['sampling_p_offset_vector']  = crossstream
             sampledict['sampling_p_offsets'] = offsetstr        
     else:

--- a/farmfunctions.py
+++ b/farmfunctions.py
@@ -970,7 +970,7 @@ def sampling_createDictForTurbine(self, turbname, tdict, pdict, defaultopt):
             downstream = scale*float(pdict['downstream'])        
             offsetvec  = np.linspace(0, upstream+downstream, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
-            sampledict['sampling_p_normal']  = streamwise
+            sampledict['sampling_p_offset_vector']  = streamwise
             sampledict['sampling_p_offsets'] = offsetstr
     # --- Create hub-height sampling planes --- 
     elif probetype == 'hubheight':
@@ -1009,7 +1009,7 @@ def sampling_createDictForTurbine(self, turbname, tdict, pdict, defaultopt):
             above      = scale*float(pdict['above'])
             offsetvec  = np.linspace(0, above+below, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
-            sampledict['sampling_p_normal']  = vert
+            sampledict['sampling_p_offset_vector']  = vert
             sampledict['sampling_p_offsets'] = offsetstr
     # --- Create streamwise sampling planes --- 
     elif probetype == 'streamwise':
@@ -1047,7 +1047,7 @@ def sampling_createDictForTurbine(self, turbname, tdict, pdict, defaultopt):
             lateral    = scale*float(pdict['lateral'])
             offsetvec  = np.linspace(0, lateral, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
-            sampledict['sampling_p_normal']  = crossstream
+            sampledict['sampling_p_offset_vector']  = crossstream
             sampledict['sampling_p_offsets'] = offsetstr        
     else:
         print("ERROR: probetype %s not recognized"%probetype)
@@ -1222,7 +1222,7 @@ def sampling_createDictForFarm(self, pdict, AvgCenter,
             above      = scale*float(pdict['above'])
             offsetvec  = np.linspace(0, above+below, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
-            sampledict['sampling_p_normal']  = vert
+            sampledict['sampling_p_offset_vector']  = vert
             sampledict['sampling_p_offsets'] = offsetstr
     # --- Create rotorplane sampling plane --- 
     elif probetype == 'rotorplane':
@@ -1260,7 +1260,7 @@ def sampling_createDictForFarm(self, pdict, AvgCenter,
             downstream = scale*float(pdict['downstream'])        
             offsetvec  = np.linspace(0, upstream+downstream, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
-            sampledict['sampling_p_normal']  = streamwise
+            sampledict['sampling_p_offset_vector']  = streamwise
             sampledict['sampling_p_offsets'] = offsetstr
 
     # --- Create streamwise sampling planes --- 
@@ -1309,7 +1309,7 @@ def sampling_createDictForFarm(self, pdict, AvgCenter,
             lateral    = scale*float(pdict['lateral'])
             offsetvec  = np.linspace(0, lateral, noffsets+1)
             offsetstr  = ' '.join([repr(x) for x in offsetvec])
-            sampledict['sampling_p_normal']  = crossstream
+            sampledict['sampling_p_offset_vector']  = crossstream
             sampledict['sampling_p_offsets'] = offsetstr        
     else:
         print("ERROR: probetype %s not recognized for farm centers"%probetype)

--- a/farmfunctions.py
+++ b/farmfunctions.py
@@ -1319,7 +1319,7 @@ def sampling_createDictForFarm(self, pdict, AvgCenter,
             sampledict['sampling_p_offsets'] = offsetstr        
     else:
         print("ERROR: probetype %s not recognized for farm centers"%probetype)
-    
+
     return sampledict
 
 def sampling_createAllProbes(self, verbose=False):

--- a/plotfunctions.py
+++ b/plotfunctions.py
@@ -288,7 +288,12 @@ def plotDomain(self, ax=None, verbose=False, plotskip=1):
                     offsets =[float(x) for x in allpdict[p+'.offsets'].split()]
                 else:
                     offsets = [0.0]
-                offsetnormal = np.array(allpdict[p+'.offset_vector'])
+                # GRY: Using try - except here to start. Is the default value None if the field does not exists though?
+                try:
+                    offsetnormal = np.array(allpdict[p+'.offset_vector'])
+                except:
+                    print("offset_vector not specified. Using legacy interface: .normal")
+                    offsetnormal = np.array(allpdict[p+'.normal'])
                 offsetvec = []
                 if len(offsets)==0:
                     offsetvec.append(np.zeros(3))

--- a/plotfunctions.py
+++ b/plotfunctions.py
@@ -291,7 +291,6 @@ def plotDomain(self, ax=None, verbose=False, plotskip=1):
                 try:
                     offsetnormal = np.array(allpdict[p+'.offset_vector'])
                 except:
-                    print("offset_vector not specified. Using legacy interface: .normal")
                     offsetnormal = np.array(allpdict[p+'.normal'])
                 offsetvec = []
                 if len(offsets)==0:

--- a/plotfunctions.py
+++ b/plotfunctions.py
@@ -288,7 +288,6 @@ def plotDomain(self, ax=None, verbose=False, plotskip=1):
                     offsets =[float(x) for x in allpdict[p+'.offsets'].split()]
                 else:
                     offsets = [0.0]
-                # GRY: Using try - except here to start. Is the default value None if the field does not exists though?
                 try:
                     offsetnormal = np.array(allpdict[p+'.offset_vector'])
                 except:

--- a/plotfunctions.py
+++ b/plotfunctions.py
@@ -288,7 +288,7 @@ def plotDomain(self, ax=None, verbose=False, plotskip=1):
                     offsets =[float(x) for x in allpdict[p+'.offsets'].split()]
                 else:
                     offsets = [0.0]
-                offsetnormal = np.array(allpdict[p+'.normal'])
+                offsetnormal = np.array(allpdict[p+'.offset_vector'])
                 offsetvec = []
                 if len(offsets)==0:
                     offsetvec.append(np.zeros(3))

--- a/postproamrwindsample_xarray.py
+++ b/postproamrwindsample_xarray.py
@@ -88,7 +88,10 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
                 db['z'] = zm        
                 db['axis1'] = ds.attrs['axis1']
                 db['axis2'] = ds.attrs['axis2']
-                db['axis3'] = ds.attrs['axis3']
+                try:
+                    db['axis3'] = ds.attrs['offset_vector']
+                except:
+                    db['axis3'] = ds.attrs['axis3']
                 R=get_mapping_xyz_to_axis1axis2(db['axis1'],db['axis2'],db['axis3'],rot=axis_rotation)
             for itime in itimevec:
                 local_ind = np.where(np.isin(times[ncfileiter], timevec[itime]))[0]
@@ -323,7 +326,10 @@ def avgPlaneXR(ncfileinput, timerange,
                 db['z'] = zm
                 db['axis1'] = ds.attrs['axis1']
                 db['axis2'] = ds.attrs['axis2']
-                db['axis3'] = ds.attrs['axis3']
+                try:
+                    db['axis3'] = ds.attrs['offset_vector']
+                except:
+                    db['axis3'] = ds.attrs['axis3']
                 db['origin'] = ds.attrs['origin']
                 db['offsets'] = ds.attrs['offsets']
             # Set up the initial mean fields

--- a/validateinputs/sampleprobes.py
+++ b/validateinputs/sampleprobes.py
@@ -52,7 +52,12 @@ def checkSamplePlaneInside(name, pdict, corner1, corner2):
     else:
         offsets = [0]
     
-    offsetnormal = np.array(pdict['sampling_p_offset_vector'])
+    # GRY: Using try - except here to start. Is the default value None if the field does not exists though?
+    try:
+        offsetnormal = np.array(pdict['sampling_p_offset_vector'])
+    except:
+        print("offset_vector not specified. Using legacy interface: .normal")
+        offsetnormal = np.array(pdict['sampling_p_normal'])
 
     # Construct the list of offsets
     offsetvec = []

--- a/validateinputs/sampleprobes.py
+++ b/validateinputs/sampleprobes.py
@@ -55,7 +55,6 @@ def checkSamplePlaneInside(name, pdict, corner1, corner2):
     try:
         offsetnormal = np.array(pdict['sampling_p_offset_vector'])
     except:
-        print("offset_vector not specified. Using legacy interface: .normal")
         offsetnormal = np.array(pdict['sampling_p_normal'])
 
     # Construct the list of offsets

--- a/validateinputs/sampleprobes.py
+++ b/validateinputs/sampleprobes.py
@@ -7,9 +7,9 @@ See README.md for details on the structure of classes here
 """
 
 def isPointInside(p, corner1, corner2):
-    inside = (corner1[0] <= p[0]) and (p[0] <= corner2[0]) and \
-             (corner1[1] <= p[1]) and (p[1] <= corner2[1]) and \
-             (corner1[2] <= p[2]) and (p[2] <= corner2[2]) 
+    inside = (corner1[0] < p[0]) and (p[0] < corner2[0]) and \
+             (corner1[1] < p[1]) and (p[1] < corner2[1]) and \
+             (corner1[2] < p[2]) and (p[2] < corner2[2]) 
     return inside
 
 def checkLineProbeInside(name, pdict, corner1, corner2):
@@ -99,7 +99,7 @@ class Check_sampleprobes_inside():
         allsamplingdata = app.listboxpopupwindict['listboxsampling']
         allprobes       = allsamplingdata.getitemlist()
 
-        if (len(allprobes)==0) or ('sampling' not in post_processing):
+        if (len(allprobes)==0): #or ('sampling' not in post_processing): #GRY: This seems to be depreciated
             skipstatus                = {}   # Dict containing return status
             skipstatus['subname']     = ''   # Additional name info
             skipstatus['result']      = status.SKIP

--- a/validateinputs/sampleprobes.py
+++ b/validateinputs/sampleprobes.py
@@ -52,7 +52,7 @@ def checkSamplePlaneInside(name, pdict, corner1, corner2):
     else:
         offsets = [0]
     
-    offsetnormal = np.array(pdict['sampling_p_normal'])
+    offsetnormal = np.array(pdict['sampling_p_offset_vector'])
 
     # Construct the list of offsets
     offsetvec = []

--- a/validateinputs/sampleprobes.py
+++ b/validateinputs/sampleprobes.py
@@ -52,7 +52,6 @@ def checkSamplePlaneInside(name, pdict, corner1, corner2):
     else:
         offsets = [0]
     
-    # GRY: Using try - except here to start. Is the default value None if the field does not exists though?
     try:
         offsetnormal = np.array(pdict['sampling_p_offset_vector'])
     except:


### PR DESCRIPTION
The latest version of AMR-Wind replaces "normal" with "offset_vector" in the plane sampler descriptions. @lawrenceccheung, I'm starting this PR to update the frontend to reflect this change. Do we want to preserve any legacy functionality for "normal" or just move everything to offset_vector as I've tried to do here?