### PR TITLE
Fix title labels in postproengine

### DIFF
--- a/postproengine/__init__.py
+++ b/postproengine/__init__.py
@@ -869,8 +869,8 @@ class contourplottemplate():
                     else:
                         # This part is outside LaTeX math mode, evaluate it
                         evaluated_parts.append(eval(f"rf'{part}'"))
-                title = ''.join(evaluated_parts)
-                ax.set_title(title,fontsize=fontsize)
+                evaltitle = ''.join(evaluated_parts)
+                ax.set_title(evaltitle,fontsize=fontsize)
 
                 ax.tick_params(axis='both', which='major', labelsize=fontsize) 
 

--- a/postproengine/instantaneousplanes.py
+++ b/postproengine/instantaneousplanes.py
@@ -284,8 +284,8 @@ instantaneousplanes:
                     else:
                         # This part is outside LaTeX math mode, evaluate it
                         evaluated_parts.append(eval(f"rf'{part}'"))
-                title = ''.join(evaluated_parts)
-                ax.set_title(title,fontsize=fontsize)
+                evaltitle = ''.join(evaluated_parts)
+                ax.set_title(evaltitle,fontsize=fontsize)
                 if axisscale is not None:
                     ax.axis(axisscale)
 


### PR DESCRIPTION
In the contour plot and instantaneous plot postpro engine, the titles weren't handled correctly for multiple plots.  This fixes that bug.
