### PR TITLE
Added plot turbines to instantaneous plots

### DIFF
--- a/postproengine/doc/controlvolume.md
+++ b/postproengine/doc/controlvolume.md
@@ -8,7 +8,7 @@ Control volume analysis
   diam                : Turbine diameter (Required)
   box_center_XYZ      : Center of control volume (XYZ coordinates) (Optional, Default: None)
   box_fr_center_XYZ   : Center of control volume on front face (XYZ coordinates) (Optional, Default: None)
-  box_fr_streamwise_offset: Streamwise offset when specifying front face of control volume in turbine diameters (Optional, Default: 0)
+  box_fr_streamwise_offset: Streamwise offset when specifying front face of control volume, in turbine diameters (Optional, Default: 0)
   rho                 : Density (Required)
   latitude            : Latitude (Required)
   body_force_XYZ      : Body force from AMR-Wind input file (XYZ coordinates) (Required)
@@ -48,13 +48,15 @@ controlvolume:
   latitude: 39.55
   box_center_XYZ: [3000.0,1000.0,150.0]
   #box_fr_center_XYZ: [2280.0,1000.0,150.0]
+  #box_fr_streamwise_offset: 0
   streamwise_box_size: 6
   lateral_box_size: 1
   vertical_box_size: 1
   rho: 1.2456
   body_force_XYZ: [0.00014295185866400572, 0.0008354682029301641, 0.0]
-  compute_pressure_gradient: True
   varnames: ['velocitya1','velocitya2','velocitya3']
+  compute_pressure_gradient: True
+  savepklfile: 'Control_Volume_a123.pkl'
   #varnames: ['velocityx','velocityy','velocityz']
 
   bot_avg_file: '/nscratch/kbrown1/Advanced_Control/AMR/Turbine_Runs/One_Turb/MedWS_LowTI/postpro/Data/Baseline_test_pp/postpro_avg_XY.pkl'

--- a/postproengine/doc/instantaneousplanes.md
+++ b/postproengine/doc/instantaneousplanes.md
@@ -8,11 +8,11 @@ Make instantaneous plots from netcdf sample planes
   iters               : Which iterations to pull from netcdf file (Required)
   xaxis               : Which axis to use on the abscissa (Required)
   yaxis               : Which axis to use on the ordinate (Required)
+  iplane              : Which plane to pull from netcdf file (Required)
   times               : Which times to pull from netcdf file (overrides iters) (Optional, Default: [])
   trange              : Pull a range of times from netcdf file (overrides iters) (Optional, Default: None)
   group               : Which group to pull from netcdf file (Optional, Default: None)
   varnames            : Variables to extract from the netcdf file (Optional, Default: ['velocityx', 'velocityy', 'velocityz'])
-  iplane              : Which plane to pull from netcdf file (Required)
 ```
 
 ## Actions: 
@@ -38,6 +38,7 @@ Make instantaneous plots from netcdf sample planes
     axesnumfunc       : Function to determine which subplot axes to create plot in (lambda expression with iplane as arg) (Optional, Default: None)
     axesnumfunc       : Function to determine which subplot axes to create plot in (lambda expression with iplane as arg) (Optional, Default: None)
     axisscale         : Aspect ratio of figure axes (options:equal,scaled,tight,auto,image,square) (Optional, Default: 'scaled')
+    plotturbines      : List of dictionaries which contain turbines to plot (Optional, Default: None)
   interpolate         : ACTION: Interpolate data from an arbitrary set of points (Optional)
     pointlocationfunction: Function to call to generate point locations. Function should have no arguments and return a list of points (Required)
     pointcoordsystem  : Coordinate system for point interpolation.  Options: XYZ, A1A2 (Required)

--- a/postproengine/instantaneousplanes.py
+++ b/postproengine/instantaneousplanes.py
@@ -19,6 +19,7 @@ from postproengine import convert_vel_xyz_to_axis1axis2
 import cv2
 from postproengine import spod
 import re
+import plotfunctions
 
 """
 Plugin for creating instantaneous planar images
@@ -47,6 +48,8 @@ class postpro_instantaneousplanes():
         'help':'Which axis to use on the abscissa', },
         {'key':'yaxis',    'required':True,  'default':'y',
         'help':'Which axis to use on the ordinate', },
+        {'key':'iplane',   'required':True,  'default':0,
+         'help':'Which plane to pull from netcdf file', },
         # --- optional parameters ---
         {'key':'times',    'required':False,  'default':[],
          'help':'Which times to pull from netcdf file (overrides iters)', },        
@@ -56,8 +59,7 @@ class postpro_instantaneousplanes():
          'help':'Which group to pull from netcdf file', },
         {'key':'varnames',  'required':False,  'default':['velocityx', 'velocityy', 'velocityz'],
          'help':'Variables to extract from the netcdf file',},        
-        {'key':'iplane',   'required':True,  'default':0,
-        'help':'Which plane to pull from netcdf file', },
+
     ]
     actionlist = {}                    # Dictionary for holding sub-actions
     example = """
@@ -210,6 +212,8 @@ instantaneousplanes:
              'help':'Function to determine which subplot axes to create plot in (lambda expression with iplane as arg)'},
             {'key':'axisscale',    'required':False,  'default':'scaled',
              'help':'Aspect ratio of figure axes (options:equal,scaled,tight,auto,image,square)'},
+            {'key':'plotturbines',   'required':False,  'default':None,
+             'help':'List of dictionaries which contain turbines to plot', },
 
         ]
         def __init__(self, parent, inputs):
@@ -239,6 +243,7 @@ instantaneousplanes:
             figname  = self.actiondict['figname']
             axesnumf = None if self.actiondict['axesnumfunc'] is None else eval(self.actiondict['axesnumfunc'])
             axisscale= self.actiondict['axisscale']
+            plotturbs= self.actiondict['plotturbines']
 
             # Loop through each time instance and plot
             iplane = self.parent.iplane
@@ -288,6 +293,21 @@ instantaneousplanes:
                 ax.set_title(evaltitle,fontsize=fontsize)
                 if axisscale is not None:
                     ax.axis(axisscale)
+
+                # Plot turbines
+                if plotturbs:
+                    axismapping = {'x':0, 'a1':0, 'y':1, 'a2':1, 'z':2, 'a3':2}
+                    defaultlstyle =  {'lw':1, 'color':'k', 'alpha':0.75}
+                    for turb in plotturbs:
+                        basexyz   = turb['basexyz']
+                        hubheight = turb['hubheight']
+                        turbD     = turb['rotordiameter']
+                        nacelledir= turb['nacelledir']
+                        ix        = turb['ix'] if 'ix' in turb else axismapping[self.parent.xaxis]
+                        iy        = turb['iy'] if 'iy' in turb else axismapping[self.parent.yaxis]
+                        lstyle    = turb['linestyle'] if 'linestyle' in turb else defaultlstyle
+                        plotfunctions.plotTurbine(ax, basexyz, hubheight, turbD, nacelledir, ix, iy,
+                                                  **lstyle)
 
                 # Run any post plot functions
                 if len(postplotfunc)>0:


### PR DESCRIPTION
Added an option to include turbine schematic into the instantaneous plots
```yaml
    plot:
        title: '2 Turbine NOW23 $U_h$ t={(time-8000):0.1f}s'
        plotfunc: "lambda db,i: np.sqrt(db['velocityx'][i]**2 + db['velocityy'][i]**2)"    
        clevels: 'np.linspace(8, 18, 101)'
        xlabel: 'X [m]'
        ylabel: 'Y [m]'
        fontsize: 12
        savefile: FarmRun_Plots/TwoTurb_HHdomain.png
        figsize: [5,5]
        plotturbines:
        - {'basexyz':[-750.0,-500.0,0.0], 'hubheight':150.0, 'rotordiameter':240, 'nacelledir':247.8833, }
        - {'basexyz':[584.0432641485886, 42.151795514668265, 0.0], 'hubheight':150.0, 'rotordiameter':240, 'nacelledir':247.8833, }
```
which generates:
![image](https://github.com/user-attachments/assets/bfe0be9b-c51e-4f5f-b68b-5ed7a9ebf854)