### PR TITLE
Added spanwiseloading action to openfast executor

### DIFF
--- a/postproengine/doc/openfast.md
+++ b/postproengine/doc/openfast.md
@@ -32,3 +32,36 @@ Postprocessing of openfast variables
     radialstations    : list of radial blade stations (Required)
     prefix            : Prefix in front of each openfast var (Optional, Default: 'AB1N')
 ```
+
+## Example
+```yaml
+openfast:
+- name: NREL5MW_SECLOADS
+  filename: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast-cpp/5MW_Land_DLL_WTurb_cpp/5MW_Land_DLL_WTurb_cpp.out
+  vars: 
+  - Time
+  - '^Rot'
+  - 'AB1N...Alpha'
+  - 'AB1N...Phi'
+  - 'AB1N...Cl'
+  - 'AB1N...Cd'
+  - 'AB1N...Fx'
+  - 'AB1N...Fy'
+  - RotSpeed
+  output_dir: RESULTSDIR
+  useregex: True
+  csv:  # Store information to CSV files
+    individual_files: False
+  operate:
+    operations: 
+    - mean
+    trange: [300, 900]
+  spanwiseloading:
+    bladefile: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast/5MW_Baseline/NRELOffshrBsline5MW_AeroDyn_blade.dat
+    bladevars: [Alpha, Phi, Cl, Cd, Fx, Fy]
+    meancsvfile: RESULTSDIR/NREL5MW_SECLOADS_mean.csv
+    savecsvfile: RESULTSDIR/NREL5MW_SECLOADS_mean_rpts.csv
+    radialstations: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+    prefix: AB1N
+
+```

--- a/postproengine/doc/openfast.md
+++ b/postproengine/doc/openfast.md
@@ -8,6 +8,7 @@ Postprocessing of openfast variables
   vars                : Variables to extract from the openfast file (Required)
   extension           : The extension to use for the csv files (Optional, Default: '.csv')
   output_dir          : Directory to save results (Optional, Default: './')
+  useregex            : Use regex expansion in vars list (Optional, Default: False)
 ```
 
 ## Actions: 
@@ -23,4 +24,11 @@ Postprocessing of openfast variables
     diam              : Turbine diameter (Optional, Default: 0)
     U_st              : Wind speed to define Strouhal number (Optional, Default: 0)
     nperseg           : Number of samples per segment used in pwelch (Optional, Default: 4096)
+  spanwiseloading     : ACTION: Reformats time history csv data to spanwise loading profiles (Optional)
+    bladefile         : AeroDyn blade file (Required)
+    bladevars         : List of blade variables to extract, such as Alpha, Cl, Cd, etc. (Required)
+    meancsvfile       : mean csv file (output from above) (Required)
+    savecsvfile       : output csv file (Required)
+    radialstations    : list of radial blade stations (Required)
+    prefix            : Prefix in front of each openfast var (Optional, Default: 'AB1N')
 ```

--- a/postproengine/openfast.py
+++ b/postproengine/openfast.py
@@ -94,7 +94,36 @@ class postpro_openfast():
 
     ]
     actionlist = {}                    # Dictionary for holding sub-actions
-
+    example = """
+openfast:
+- name: NREL5MW_SECLOADS
+  filename: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast-cpp/5MW_Land_DLL_WTurb_cpp/5MW_Land_DLL_WTurb_cpp.out
+  vars: 
+  - Time
+  - '^Rot'
+  - 'AB1N...Alpha'
+  - 'AB1N...Phi'
+  - 'AB1N...Cl'
+  - 'AB1N...Cd'
+  - 'AB1N...Fx'
+  - 'AB1N...Fy'
+  - RotSpeed
+  output_dir: RESULTSDIR
+  useregex: True
+  csv:  # Store information to CSV files
+    individual_files: False
+  operate:
+    operations: 
+    - mean
+    trange: [300, 900]
+  spanwiseloading:
+    bladefile: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast/5MW_Baseline/NRELOffshrBsline5MW_AeroDyn_blade.dat
+    bladevars: [Alpha, Phi, Cl, Cd, Fx, Fy]
+    meancsvfile: RESULTSDIR/NREL5MW_SECLOADS_mean.csv
+    savecsvfile: RESULTSDIR/NREL5MW_SECLOADS_mean_rpts.csv
+    radialstations: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
+    prefix: AB1N
+"""
     # --- Stuff required for main task ---
     def __init__(self, inputs, verbose=False):
         self.yamldictlist = []


### PR DESCRIPTION
This adds two things to the openfast executor:
1.  Adds a spanwiseloading action so that the mean spanwise loading profiles can be calculated from the mean csv file
2.  Allows for regex expansions in the `vars` input to the openfast executor.  By default `useregex` is False to avoid confusion with extra matches.

This means that you can now calculate spanwise loading in a single section like this:
```yaml
openfast:
- name: NREL5MW_SECLOADS
  filename: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast-cpp/5MW_Land_DLL_WTurb_cpp/5MW_Land_DLL_WTurb_cpp.out
  vars: 
  - Time
  - '^Rot'
  - 'AB1N...Alpha'
  - 'AB1N...Phi'
  - 'AB1N...Cl'
  - 'AB1N...Cd'
  - 'AB1N...Fx'
  - 'AB1N...Fy'
  - RotSpeed
  output_dir: RESULTSDIR
  useregex: True
  csv:  # Store information to CSV files
    individual_files: False
  operate:
    operations: 
    - mean
    trange: *trange
  spanwiseloading:
    bladefile: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast/5MW_Baseline/NRELOffshrBsline5MW_AeroDyn_blade.dat
    bladevars: [Alpha, Phi, Cl, Cd, Fx, Fy]
    meancsvfile: RESULTSDIR/NREL5MW_SECLOADS_mean.csv
    savecsvfile: RESULTSDIR/NREL5MW_SECLOADS_mean_rpts.csv
    radialstations: [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19]
    prefix: AB1N
```