### PR TITLE
Fix problem with finding the right checkpoint directory for restarting

### DIFF
--- a/utilities/restartAMRWind.py
+++ b/utilities/restartAMRWind.py
@@ -141,7 +141,7 @@ Example usage:
     parser.add_argument(
         "--sort-method",
         dest='sortmethod',
-        help="Choose which method to use when selecting the restart checkpoint",
+        help="Choose which method to use when selecting the restart checkpoint (Default: lastsimtime)",
         default='lastsimtime',
         choices=['lastsimtime', 'lastiter','lastcreated']
     )


### PR DESCRIPTION
We have been experiencing problems where `restartAMRwind.py` was not choosing the right checkpoint directory due to the filesystem altering directory creation times after the run.  This fixes the issue by sorting the directories based on different criteria.  Now by default it looks for the checkpoint with the latest simulation time, although other sorting methods are also possible.  See the `--sort-method` option that is now added:
```
  --sort-method {lastsimtime,lastiter,lastcreated}
                        Choose which method to use when selecting the restart checkpoint (Default: lastsimtime)
```