### PR TITLE
Update to getPlaneXR for extracting data from multiple netcdf files

### DIFF
--- a/postproamrwindsample_xarray.py
+++ b/postproamrwindsample_xarray.py
@@ -146,16 +146,11 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
 
     find_nearest = lambda a, a0: np.abs(np.array(a) - a0).argmin()
 
-
     #Apply transformation after computing cartesian average
     transform=False
     if varnames == ['velocitya1','velocitya2','velocitya3']:
         transform = True
         varnames = ['velocityx','velocityy','velocityz']
-
-    #overwrite itimevec if specifying times or time range
-    if times is not None or timerange is not None:
-        itimevec = []
 
     all_timevecs = np.concatenate(timevecs)
     if times is not None:
@@ -206,6 +201,7 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
                     local_ind = np.argmin( np.abs(time-timevec))
                     if verbose>0:
                         print("extracting iter "+repr(itime))
+                    print("extracting iter "+repr(itime),time)
                     db['timesteps'].append(itime)
                     if gettimes:
                         db['times'].append(float(all_timevecs[itime]))

--- a/postproengine/doc/instantaneousplanes.md
+++ b/postproengine/doc/instantaneousplanes.md
@@ -5,12 +5,12 @@ Make instantaneous plots from netcdf sample planes
 ```
   name                : An arbitrary name (Required)
   ncfile              : NetCDF sampling file (Required)
-  iters               : Which iterations to pull from netcdf file (Required)
+  iters               : Which iterations to pull from netcdf file (Optional, Default: [])
+  times               : Which times to pull from netcdf file (Optional, Default: None)
+  trange              : Pull a range of times from netcdf file (Optional, Default: None)
   xaxis               : Which axis to use on the abscissa (Required)
   yaxis               : Which axis to use on the ordinate (Required)
   iplane              : Which plane to pull from netcdf file (Required)
-  times               : Which times to pull from netcdf file (overrides iters) (Optional, Default: None)
-  trange              : Pull a range of times from netcdf file (overrides iters) (Optional, Default: None)
   group               : Which group to pull from netcdf file (Optional, Default: None)
   varnames            : Variables to extract from the netcdf file (Optional, Default: ['velocityx', 'velocityy', 'velocityz'])
   savepklfile         : Name of pickle file to save results (Optional, Default: '')
@@ -81,8 +81,9 @@ Make instantaneous plots from netcdf sample planes
 instantaneousplanes:
   name: Wake YZ plane
   ncfile: ./data_converter/PA_1p25_new2/YZslice_01.00D_456.00s_1556.00s_n1m.nc
-  iters: [0,]
-  #trange: [456,457]
+  iters: [0,10,20]
+  trange: [456,1056]
+  times: [1100,1200,1300]
   xaxis: 'y'
   yaxis: 'z'
   varnames: ['velocityx','velocityy','velocityz']
@@ -90,7 +91,7 @@ instantaneousplanes:
 
   plot:
     plotfunc: "lambda db, i: db['velocityx'][i]"
-    savefile: 'inst_figs_n1m/inst_test_{time}.png'
+    savefile: 'inst_figs_n1m/inst_test_{iter}.png'
     figsize: [8,5]
     dpi: 125
     xlabel: 'Y [m]'
@@ -102,7 +103,7 @@ instantaneousplanes:
   animate:
     name: 'output.mp4'
     fps: 20
-    imagefilename: './inst_figs_n1m/inst_test_{time}.png'
+    imagefilename: './inst_figs_n1m/inst_test_{iter}.png'
     #times: 'np.arange(456,1556.5,0.5)'
 
   plot_radial:

--- a/postproengine/doc/instantaneousplanes.md
+++ b/postproengine/doc/instantaneousplanes.md
@@ -9,7 +9,7 @@ Make instantaneous plots from netcdf sample planes
   xaxis               : Which axis to use on the abscissa (Required)
   yaxis               : Which axis to use on the ordinate (Required)
   iplane              : Which plane to pull from netcdf file (Required)
-  times               : Which times to pull from netcdf file (overrides iters) (Optional, Default: [])
+  times               : Which times to pull from netcdf file (overrides iters) (Optional, Default: None)
   trange              : Pull a range of times from netcdf file (overrides iters) (Optional, Default: None)
   group               : Which group to pull from netcdf file (Optional, Default: None)
   varnames            : Variables to extract from the netcdf file (Optional, Default: ['velocityx', 'velocityy', 'velocityz'])

--- a/postproengine/instantaneousplanes.py
+++ b/postproengine/instantaneousplanes.py
@@ -48,8 +48,12 @@ class postpro_instantaneousplanes():
          'help':'An arbitrary name',},
         {'key':'ncfile',   'required':True,  'default':'',
         'help':'NetCDF sampling file', },
-        {'key':'iters',    'required':True,  'default':2,
+        {'key':'iters',    'required':False,  'default':[],
         'help':'Which iterations to pull from netcdf file', },
+        {'key':'times',    'required':False,  'default':None,
+         'help':'Which times to pull from netcdf file', },        
+        {'key':'trange',    'required':False,  'default':None,
+         'help':'Pull a range of times from netcdf file', },        
         {'key':'xaxis',    'required':True,  'default':'x',
         'help':'Which axis to use on the abscissa', },
         {'key':'yaxis',    'required':True,  'default':'y',
@@ -57,10 +61,6 @@ class postpro_instantaneousplanes():
         {'key':'iplane',   'required':True,  'default':0,
          'help':'Which plane to pull from netcdf file', },
         # --- optional parameters ---
-        {'key':'times',    'required':False,  'default':None,
-         'help':'Which times to pull from netcdf file (overrides iters)', },        
-        {'key':'trange',    'required':False,  'default':None,
-         'help':'Pull a range of times from netcdf file (overrides iters)', },        
         {'key':'group',   'required':False,  'default':None,
          'help':'Which group to pull from netcdf file', },
         {'key':'varnames',  'required':False,  'default':['velocityx', 'velocityy', 'velocityz'],
@@ -75,8 +75,9 @@ class postpro_instantaneousplanes():
 instantaneousplanes:
   name: Wake YZ plane
   ncfile: ./data_converter/PA_1p25_new2/YZslice_01.00D_456.00s_1556.00s_n1m.nc
-  iters: [0,]
-  #trange: [456,457]
+  iters: [0,10,20]
+  trange: [456,1056]
+  times: [1100,1200,1300]
   xaxis: 'y'
   yaxis: 'z'
   varnames: ['velocityx','velocityy','velocityz']
@@ -84,7 +85,7 @@ instantaneousplanes:
 
   plot:
     plotfunc: "lambda db, i: db['velocityx'][i]"
-    savefile: 'inst_figs_n1m/inst_test_{time}.png'
+    savefile: 'inst_figs_n1m/inst_test_{iter}.png'
     figsize: [8,5]
     dpi: 125
     xlabel: 'Y [m]'
@@ -96,7 +97,7 @@ instantaneousplanes:
   animate:
     name: 'output.mp4'
     fps: 20
-    imagefilename: './inst_figs_n1m/inst_test_{time}.png'
+    imagefilename: './inst_figs_n1m/inst_test_{iter}.png'
     #times: 'np.arange(456,1556.5,0.5)'
 
   plot_radial:


### PR DESCRIPTION
This PR updates the getPlaneXR() routine for extracting data from multiple netcdf files. It also extends the instantaneousplanes executor to use this new version of getPlaneXR() and allows for any combinations of iters, times, and timerange to be specified for extracting data from the netcdf files. 