### PR TITLE
Bug fix in getPlaneXR when reading data across multiple netcdf files

### DIFF
--- a/postproamrwindsample_xarray.py
+++ b/postproamrwindsample_xarray.py
@@ -201,7 +201,6 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
                     local_ind = np.argmin( np.abs(time-timevec))
                     if verbose>0:
                         print("extracting iter "+repr(itime))
-                    print("extracting iter "+repr(itime),time)
                     db['timesteps'].append(itime)
                     if gettimes:
                         db['times'].append(float(all_timevecs[itime]))

--- a/postproamrwindsample_xarray.py
+++ b/postproamrwindsample_xarray.py
@@ -152,7 +152,15 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
         transform = True
         varnames = ['velocityx','velocityy','velocityz']
 
-    all_timevecs = np.concatenate(timevecs)
+    #concatenate timevecs in order without duplicates 
+    all_timevecs = []
+    for ncfileiter,ncfile in enumerate(ncfilelistsorted):
+        timevec     = timevecs[ncfileiter]
+        extracttime = extracttimes[ncfileiter]
+        for time in timevec:
+            if time >= extracttime[0] and time <= extracttime[1]:
+                all_timevecs.append(time)
+
     if times is not None:
         for time in times:
             itimevec.append(np.argmin( np.abs( all_timevecs - time ) ))
@@ -178,6 +186,8 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
             group = groupname
 
         with xr.open_dataset(ncfile, group=group) as ds:
+            if verbose>0:
+                print("Extracting from ncfile: ",ncfile,ncfileiter)
             if ncfileiter == 0:
                 reshapeijk = ds.attrs['ijk_dims'][::-1]
                 xm = ds['coordinates'].data[:,0].reshape(tuple(reshapeijk))
@@ -198,7 +208,7 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
             for itime in itimevec:
                 time = all_timevecs[itime]
                 if itime not in itime_processed and time >= extracttime[0] and time <= extracttime[1]:
-                    local_ind = np.argmin( np.abs(time-timevec))
+                    local_ind = np.argmin(np.abs(time-timevec))
                     if verbose>0:
                         print("extracting iter "+repr(itime))
                     db['timesteps'].append(itime)

--- a/postproengine/dataconverters.py
+++ b/postproengine/dataconverters.py
@@ -160,7 +160,7 @@ bts:
         def execute(self):
 
             def get_plane_data(ncfile,varnames,group,trange,iplanes,xaxis,yaxis):
-                db = ppsamplexr.getPlaneXR(ncfile,[0,1],varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
+                db = ppsamplexr.getPlaneXR(ncfile,[],varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
                 if iplanes == None: 
                     if isinstance(db['offsets'], np.ndarray):
                         iplanes = list(range(len(db['offsets'])))

--- a/postproengine/spod.py
+++ b/postproengine/spod.py
@@ -369,7 +369,7 @@ def extract_1d_from_meshgrid(Z):
 
 def read_cart_data(ncfile,varnames,group,trange,iplanes,xaxis,yaxis):
 
-    db = ppsamplexr.getPlaneXR(ncfile,[0,1],varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
+    db = ppsamplexr.getPlaneXR(ncfile,[],varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
     if iplanes == None: 
         if isinstance(db['offsets'], np.ndarray):
             iplanes = list(range(len(db['offsets'])))

--- a/postproengine/wake_meandering.py
+++ b/postproengine/wake_meandering.py
@@ -203,7 +203,7 @@ class postpro_wakemeander():
 
             udata = {}
             xc = {}
-            self.db = ppsamplexr.getPlaneXR(ncfile,[0,1],self.varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
+            self.db = ppsamplexr.getPlaneXR(ncfile,[],self.varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
 
             if iplanes == None: 
                 try:

--- a/postproengine/wavenumberspectra.py
+++ b/postproengine/wavenumberspectra.py
@@ -28,7 +28,7 @@ def get_angular_wavenumbers(N,L):
     return k
 
 def read_cart_data(ncfile,varnames,group,trange,iplanes,xaxis,yaxis):
-    db = ppsamplexr.getPlaneXR(ncfile,[0,1],varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
+    db = ppsamplexr.getPlaneXR(ncfile,[],varnames,groupname=group,verbose=0,includeattr=True,gettimes=True,timerange=trange)
     if iplanes == None: 
         if isinstance(db['offsets'], np.ndarray):
             iplanes = list(range(len(db['offsets'])))


### PR DESCRIPTION
Two bug fixes are addressed in this PR: 

1. It was possible for duplicate times to show up when using getPlaneXR to read data across multiple files
2. Due to the recent changes to getPlaneXR, the first two timesteps were always included in some of the executors, because iters has a default value of [0,1]. 