### PR TITLE
Pitch Travel Computation

### DIFF
--- a/postproamrwindsample_xarray.py
+++ b/postproamrwindsample_xarray.py
@@ -160,6 +160,7 @@ def getPlaneXR(ncfileinput, itimevec, varnames, groupname=None,
         for time in timevec:
             if time >= extracttime[0] and time <= extracttime[1]:
                 all_timevecs.append(time)
+    all_timevecs = np.asarray(all_timevecs)
 
     if times is not None:
         for time in times:

--- a/postproengine/doc/openfast.md
+++ b/postproengine/doc/openfast.md
@@ -16,7 +16,7 @@ Postprocessing of openfast variables
   csv                 : ACTION: Writes the openfast variables to a csv file (Optional)
     individual_files  : Write each variable to a separate csv file (Optional, Default: True)
   operate             : ACTION: Operates on the openfast data and saves to a csv file (Optional)
-    operations        : List of operations to perform (mean,std,DEL,pwelch) (Required)
+    operations        : List of operations to perform (mean,std,DEL,pwelch,running_avg) (Required)
     trange            : Times to apply operation over (Optional, Default: [])
     awc_period        : Average over equal periods for AWC forcing (Optional, Default: False)
     awc               : AWC case name [baseline,n0,n1p,n1m,n1p1m_cl00,n1p1m_cl90] (Optional, Default: 'baseline')
@@ -24,6 +24,7 @@ Postprocessing of openfast variables
     diam              : Turbine diameter (Optional, Default: 0)
     U_st              : Wind speed to define Strouhal number (Optional, Default: 0)
     nperseg           : Number of samples per segment used in pwelch (Optional, Default: 4096)
+    pitch_travel      : Option to compute the pitch travel (Optional, Default: False)
   spanwiseloading     : ACTION: Reformats time history csv data to spanwise loading profiles (Optional)
     bladefile         : AeroDyn blade file (Required)
     bladevars         : List of blade variables to extract, such as Alpha, Cl, Cd, etc. (Required)
@@ -55,6 +56,10 @@ openfast:
   filename: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast-cpp/5MW_Land_DLL_WTurb_cpp/5MW_Land_DLL_WTurb_cpp.out
   vars: 
   - Time
+  - BldPitch1
+  - BldPitch2
+  - BldPitch3
+  - GenPwr
   - '^Rot'
   - 'AB1N...Alpha'
   - 'AB1N...Phi'
@@ -71,6 +76,7 @@ openfast:
     operations: 
     - mean
     trange: [300, 900]
+    pitch_travel: True
   spanwiseloading:
     bladefile: RUNDIR/T0_NREL5MW_v402_ROSCO/openfast/5MW_Baseline/NRELOffshrBsline5MW_AeroDyn_blade.dat
     bladevars: [Alpha, Phi, Cl, Cd, Fx, Fy]

--- a/postproengine/openfast.py
+++ b/postproengine/openfast.py
@@ -380,7 +380,7 @@ openfast:
                 csvfile = os.path.join(output_dir, prefix + "_running_avg" + extension)
                 running_avg_df.to_csv(csvfile, index=False,float_format='%.15f')
 
-            if 'pitch_travel':
+            if pitch_travel:
                 pitch_travel_columns  = filtered_df.filter(regex='Pitch',axis=1).columns
                 if pitch_travel_columns.empty:
                     print("No variables found containing 'Pitch'. Add to array of vars.")

--- a/postproengine/openfast.py
+++ b/postproengine/openfast.py
@@ -387,7 +387,7 @@ openfast:
                 else:
                     pitch_travel_df = pd.DataFrame(0,index=range(1),columns=pitch_travel_columns)
                     for column in pitch_travel_columns:
-                        pitch_travel = np.sum(np.abs(np.asarray(filtered_df[column][mask].values)))
+                        pitch_travel = np.sum(np.abs(np.asarray(np.diff(filtered_df[column][mask].values))))
                         pitch_travel_df[column] = pitch_travel
                     csvfile = os.path.join(output_dir, prefix + "_pitch_travel" + extension)
                     pitch_travel_df.to_csv(csvfile, index=False,float_format='%.15f')


### PR DESCRIPTION
This PR adds the option to compute the total pitch travel as part of the `operate` action in the OpenFAST executor of the postprocessing engine. 

Note: `travel` is not a new option for the operations keyword, since it only makes sense for the blade pitch (or yaw) signals. So instead, there is a separate option in the operate-action for computing pitch travel. 